### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "alessandrotesoro/wp-usergen-cli",
     "description": "Simple command to generate random users for testing purposes.",
+    "type": "wp-cli-package",
     "homepage": "https://github.com/alessandrotesoro/wp-usergen-cli",
     "license": "MIT",
     "require": {


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567